### PR TITLE
BUG: Fix navbar to stick to top of page at all times

### DIFF
--- a/src/CSS/Navbar.css
+++ b/src/CSS/Navbar.css
@@ -13,6 +13,9 @@ a {
   background-color: var(--bg);
   padding: 1rem 1.5rem 1.8rem;
   border-bottom: 2px solid var(--nav-bottom);
+  position: sticky;
+  top: 0;
+  z-index: 5;
 }
 
 .navbar-nav {


### PR DESCRIPTION
Author: Aryakoste

Fixes https://github.com/swecc-uw/swecc-website/issues/33

## What changes were made?
I made the navbar position:sticky with top:0 so that it sticks to the top at all times regardless of scroll.

## Why are these changes important/necessary?
The navbar was not visible when we scroll down which made navigation a little bit cumbersome. 

## (If applicable) Screenshots of your changes. Providing an “old vs. new” comparison would be great!
