### PR TITLE
changed the variables --text-color, --text-subtitle-color, and --text-title-color to be more blue and legible while maintaining purple theme and undertones

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,9 +2,9 @@
   --bg: #fcfcfc;
   --bg-accent: #f0f0f0;
   --bg-hover: #dcdcdc;
-  --text-color: #754ec4;
-  --text-subtitle-color: #5d3a9e;
-  --text-title-color: #4e2b8e;
+  --text-color: #656FB3;
+  --text-subtitle-color: #565FB0;
+  --text-title-color: #4A4DA2;
   --text-header-color: #412675;
   --text-header-shadow-color: rgba(0, 0, 0, 0.5);
   --nav-bottom: #3e2076;
@@ -17,7 +17,6 @@
   --backgroundImg-buttom: #474a4d;
   --backgroundImg-buttom-background: rgba(255, 255, 255, 30%);
   --backgroundImg-cover-opacity: 0.5;
-
 }
 
 .dark-mode {


### PR DESCRIPTION
Author:  Misha Nivota

## What changes were made?
As per the requested bug fix, I changed the text blocks in the home page to be more blue and readable, while keeping their purple undertones to stick with the purple theme that SWECC has. 

## Why are these changes important/necessary?
These changes are important because they ensure the text on the home page is legible and readable to all who may visit the site, as well as visually appealing. 

## (If applicable) Screenshots of your changes. Providing an “old vs. new” comparison would be great!
