### PR TITLE
Add action to message discord on PRs

### DIFF
--- a/.github/workflows/management-bots.yaml
+++ b/.github/workflows/management-bots.yaml
@@ -1,0 +1,15 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'Marking as stale since there has been no activity for 30 days. Please comment if you are still interested in this issue.'
+          stale-pr-message:  'Marking as stale since there has been no activity for 30 days. Will close in 7 days if no activity.'
+          days-before-stale: 30
+      

--- a/.github/workflows/message-discord.yaml
+++ b/.github/workflows/message-discord.yaml
@@ -13,17 +13,27 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
-          # Construct the message based on the type of PR event
           if [[ "${{ github.event.action }}" == "opened" ]]; then
-            MESSAGE="📢 A new pull request has been opened in \`${{ github.repository }}\` by \`${{ github.actor }}\`.\n🔗 [PR #${{ github.event.number }} - ${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})";
+            MESSAGE="📢 A new pull request has been opened in \`${{ github.repository }}\`"
+            MESSAGE+=" by \`${{ github.actor }}\`.\n"
+            MESSAGE+="🔗 [PR #${{ github.event.number }} - ${{ github.event.pull_request.title }}]"
+            MESSAGE+="(${{ github.event.pull_request.html_url }})"
+
           elif [[ "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
-            MESSAGE="✅ Pull request \`${{ github.event.pull_request.title }}\` in \`${{ github.repository }}\` has been merged by \`${{ github.actor }}\`.\n🔗 [PR #${{ github.event.number }}](${{ github.event.pull_request.html_url }})";
+            MESSAGE="✅ Pull request \`${{ github.event.pull_request.title }}\` in \`${{ github.repository }}\`"
+            MESSAGE+=" has been merged by \`${{ github.actor }}\`.\n"
+            MESSAGE+="🔗 [PR #${{ github.event.number }}]"
+            MESSAGE+="(${{ github.event.pull_request.html_url }})"
+
           elif [[ "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged }}" != "true" ]]; then
-            MESSAGE="❌ Pull request \`${{ github.event.pull_request.title }}\` in \`${{ github.repository }}\` has been closed without merging by \`${{ github.actor }}\`.\n🔗 [PR #${{ github.event.number }}](${{ github.event.pull_request.html_url }})";
+            MESSAGE="❌ Pull request \`${{ github.event.pull_request.title }}\` in \`${{ github.repository }}\`"
+            MESSAGE+=" has been closed without merging by \`${{ github.actor }}\`.\n"
+            MESSAGE+="🔗 [PR #${{ github.event.number }}]"
+            MESSAGE+="(${{ github.event.pull_request.html_url }})"
           else
             exit 0;  # Exit for any other PR events (not interested)
           fi
 
           curl -H "Content-Type: application/json" \
-               -d "{\"content\": \"$MESSAGE\"}" \
-               $DISCORD_WEBHOOK_URL
+              -d "{\"content\": \"$MESSAGE\"}" \
+              $DISCORD_WEBHOOK_URL

--- a/.github/workflows/message-discord.yaml
+++ b/.github/workflows/message-discord.yaml
@@ -1,0 +1,29 @@
+name: Notify Discord on PR Events
+
+on:
+  pull_request:
+    types: [opened, closed]
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send Discord notification
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          # Construct the message based on the type of PR event
+          if [[ "${{ github.event.action }}" == "opened" ]]; then
+            MESSAGE="📢 A new pull request has been opened in \`${{ github.repository }}\` by \`${{ github.actor }}\`.\n🔗 [PR #${{ github.event.number }} - ${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})";
+          elif [[ "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
+            MESSAGE="✅ Pull request \`${{ github.event.pull_request.title }}\` in \`${{ github.repository }}\` has been merged by \`${{ github.actor }}\`.\n🔗 [PR #${{ github.event.number }}](${{ github.event.pull_request.html_url }})";
+          elif [[ "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged }}" != "true" ]]; then
+            MESSAGE="❌ Pull request \`${{ github.event.pull_request.title }}\` in \`${{ github.repository }}\` has been closed without merging by \`${{ github.actor }}\`.\n🔗 [PR #${{ github.event.number }}](${{ github.event.pull_request.html_url }})";
+          else
+            exit 0;  # Exit for any other PR events (not interested)
+          fi
+
+          curl -H "Content-Type: application/json" \
+               -d "{\"content\": \"$MESSAGE\"}" \
+               $DISCORD_WEBHOOK_URL


### PR DESCRIPTION
Author: Shawn

## What changes were made?
Adds action to message the github channel on discord when a PR gets created/merged/closed.

## Why are these changes important/necessary?
Helps us keep track of everything.


