### PR TITLE
Fixed the officer year defaulting to 2025 and added some future bug prevention

### DIFF
--- a/src/Components/Officers.js
+++ b/src/Components/Officers.js
@@ -14,7 +14,7 @@ const Officers = () => {
       const availableYears = [];
 
       // officer data will be out at the end of June, this will update beginning of July
-      const defaultToThisYear = currentDate.getMonth() > 5; 
+      const defaultToThisYear = currentDate.getMonth() > 0; 
 
       // check if officer json data for the current year exists first
       if (defaultToThisYear) {
@@ -27,7 +27,7 @@ const Officers = () => {
       }
 
       // add previous years back to 2022
-      for (let year = currentDate.getFullYear(); year >= 2022; year--) {
+      for (let year = currentDate.getFullYear() - 1; year >= 2022; year--) {
         try {
           await import(`../Data/officers${year}.json`);
           availableYears.push(year);

--- a/src/Components/Officers.js
+++ b/src/Components/Officers.js
@@ -3,9 +3,9 @@ import "../CSS/Officers.css";
 import ProfileCard from "./profileCard";
 
 const Officers = () => {
-  const recentYear = 2024;
-
-  const [selectedYear, setSelectedYear] = useState(recentYear);
+  const currentDate = new Date();
+  currentDate.setMonth(currentDate.getMonth() - 6);
+  const [selectedYear, setSelectedYear] = useState(currentDate.getYear());
   const [teamMembers, setTeamMembers] = useState([]);
 
   useEffect(() => {

--- a/src/Components/Officers.js
+++ b/src/Components/Officers.js
@@ -8,39 +8,33 @@ const Officers = () => {
   const [teamMembers, setTeamMembers] = useState([]);
   const [yearOptions, setYearOptions] = useState([]);
 
-  useEffect(() => {
-    const yearSetup = async () => {
-      const currentDate = new Date();
-      const availableYears = [];
+  const yearSetup = async () => {
+    const currentDate = new Date();
+    const availableYears = [];
 
-      // officer data will be out at the end of June, this will update beginning of July
-      const defaultToThisYear = currentDate.getMonth() > 0; 
+    // officer data will be out at the end of June, this will update beginning of July
+    const defaultToThisYear = currentDate.getMonth() > 5; 
 
-      // check if officer json data for the current year exists first
-      if (defaultToThisYear) {
-        try {
-          await import(`../Data/officers${currentDate.getFullYear()}.json`);
-          availableYears.push(currentDate.getFullYear());
-        } catch (error) {
-          // officer data for this year won't be added
-        }
-      }
-
-      // add previous years back to 2022
-      for (let year = currentDate.getFullYear() - 1; year >= 2022; year--) {
+    // check if officer json data for the current year should be added
+    // and exists first, then add previous years back to 2022
+    for (let year = currentDate.getFullYear(); year >= 2022; year--) {
+      if(defaultToThisYear || year !== currentDate.getFullYear()) {
         try {
           await import(`../Data/officers${year}.json`);
           availableYears.push(year);
         } catch (error) {
           // officer data for this year won't be added
+          console.log("Error loading year:", error);
         }
       }
+    }
 
-      // set year options and default year to most recent available year
-      setYearOptions(availableYears);
-      setSelectedYear(availableYears[0]);
-    };
+    // set year options and default year to most recent available year
+    setYearOptions(availableYears);
+    setSelectedYear(availableYears[0]);
+  };
 
+  useEffect(() => {
     yearSetup();
   }, []); // only runs after initial render
 

--- a/src/Components/Officers.js
+++ b/src/Components/Officers.js
@@ -3,10 +3,46 @@ import "../CSS/Officers.css";
 import ProfileCard from "./profileCard";
 
 const Officers = () => {
-  const currentDate = new Date();
-  currentDate.setMonth(currentDate.getMonth() - 6);
-  const [selectedYear, setSelectedYear] = useState(currentDate.getYear());
+  
+  const [selectedYear, setSelectedYear] = useState(null);
   const [teamMembers, setTeamMembers] = useState([]);
+  const [yearOptions, setYearOptions] = useState([]);
+
+  useEffect(() => {
+    const yearSetup = async () => {
+      const currentDate = new Date();
+      const availableYears = [];
+
+      // officer data will be out at the end of June, this will update beginning of July
+      const defaultToThisYear = currentDate.getMonth() > 5; 
+
+      // check if officer json data for the current year exists first
+      if (defaultToThisYear) {
+        try {
+          await import(`../Data/officers${currentDate.getFullYear()}.json`);
+          availableYears.push(currentDate.getFullYear());
+        } catch (error) {
+          // officer data for this year won't be added
+        }
+      }
+
+      // add previous years back to 2022
+      for (let year = currentDate.getFullYear(); year >= 2022; year--) {
+        try {
+          await import(`../Data/officers${year}.json`);
+          availableYears.push(year);
+        } catch (error) {
+          // officer data for this year won't be added
+        }
+      }
+
+      // set year options and default year to most recent available year
+      setYearOptions(availableYears);
+      setSelectedYear(availableYears[0]);
+    };
+
+    yearSetup();
+  }, []); // only runs after initial render
 
   useEffect(() => {
     const loadTeamMembers = async () => {
@@ -36,7 +72,7 @@ const Officers = () => {
           <nav className="officer-sidebar">
             <h2>Year</h2>
             <ul>
-              {[2024, 2023, 2022].map((year) => (
+              {yearOptions.map((year) => (
                 <li key={year}>
                   <button
                     onClick={() => handleYearChange(year)}

--- a/src/Components/Officers.js
+++ b/src/Components/Officers.js
@@ -3,7 +3,9 @@ import "../CSS/Officers.css";
 import ProfileCard from "./profileCard";
 
 const Officers = () => {
-  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
+  const recentYear = 2024;
+
+  const [selectedYear, setSelectedYear] = useState(recentYear);
   const [teamMembers, setTeamMembers] = useState([]);
 
   useEffect(() => {


### PR DESCRIPTION
Author: Sean Benoit

## What changes were made?
The state of the selected year was being initialized using the default current date, so I refactored the way years were being treated. I did this by checking first if the month is later than June (since officer data will be finalized by the end of June for publishing to the website) and then pushing the current year onto a list of available officer years only if the officer json data for that year existed as well (both conditions must be met). Then, I went ahead and added all previous years back to 2022. This list is now used in the sidebar of years as well, and I tested that the website will automatically adjust itself whenever "officers2025.json" is added by creating a test json file and changing the month check to January.

## Why are these changes important/necessary?
These changes are important to ensure that only the most recent available officer data is displayed by default, and in the future, the new way of handling years could help make future development of the website a bit easier.

## (If applicable) Screenshots of your changes. Providing an “old vs. new” comparison would be great!
