### PR TITLE
Changes to colors in the officier side bar

### DIFF
--- a/src/CSS/Officers.css
+++ b/src/CSS/Officers.css
@@ -142,7 +142,7 @@
   font-size: 3rem;
   font-family: adobe-garamond-pro;
   font-weight: 400;
-  color: var(--text-color);
+  color: var(--text-title-color);
   font-style: normal;
 }
 


### PR DESCRIPTION
Author: Peter Bun

## What changes were made?

Replaced broken variable with a header color. I don't know what the side bar header color used to be, but I am assuming the regular header color is appropriate (well the header color is never used in the website it seems, so I just opted in to the title color). Without it, the sidebar color will always be black, which leading to bad contrast in dark mode. I also changed the main "Officer 20XX" to use title color to more consistent to the other pages. 
  
## (If applicable) Screenshots of your changes. Providing an “old vs. new” comparison would be great!
New (left) vs. old (right)
<img width="1873" height="1067" alt="image" src="https://github.com/user-attachments/assets/d12356c2-6763-4f11-ba06-4704b642c838" />

