### PR TITLE
removed sponsor button from navbar

### DIFF
--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -112,14 +112,7 @@ function Navbar() {
             tooltip="Officers"
             label="Officers"
           />
-          <NavItem
-            icon=<FaHeart />
-            route="/Sponsor"
-            expand={expand}
-            closeExpand={closeExpand}
-            tooltip="Sponsor"
-            label="Sponsors"
-          />
+          
           <NavItem
             icon=<FcCalendar />
             route="/Events"


### PR DESCRIPTION
Author: Justin Hernandez Tovalin

## What changes were made?
Removed the Sponsors from the navbar

## Why are these changes important/necessary?
The button is unused and not implemented so it creates user confusion

## (If applicable) Screenshots of your changes. Providing an “old vs. new” comparison would be great!
Before: 
<img width="1512" height="982" alt="Screenshot 2026-01-05 at 2 34 47 PM" src="https://github.com/user-attachments/assets/d6438514-5b27-47d8-b5db-3f9f4503904b" />

After:
<img width="1512" height="982" alt="Screenshot 2026-01-05 at 2 35 43 PM" src="https://github.com/user-attachments/assets/ff2964e2-ec6a-4e3c-a8ea-9f2001ecd880" />
